### PR TITLE
Hw2 pratham webhook clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.env
+events.db
+venv/
+__pycache__/
+*.log
+tmp/

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,96 @@
+import hmac, hashlib, json, os, time
+from typing import Optional, List
+from fastapi import FastAPI, Request, HTTPException, Header
+from fastapi.responses import Response
+from pydantic import BaseModel
+import aiosqlite
+from dotenv import load_dotenv
+
+load_dotenv()
+
+WEBHOOK_SECRET = os.getenv("WEBHOOK_SECRET", "")
+PORT = int(os.getenv("PORT", "5000"))
+
+app = FastAPI(title="GitHub Issues Gateway")
+
+DB_PATH = "events.db"
+
+async def init_db():
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS events (
+              id TEXT PRIMARY KEY,
+              event TEXT NOT NULL,
+              action TEXT,
+              issue_number INTEGER,
+              timestamp INTEGER NOT NULL
+            )
+        """)
+        await db.commit()
+
+@app.on_event("startup")
+async def on_startup():
+    await init_db()
+
+def verify_signature(secret: str, body: bytes, signature_header: Optional[str]) -> bool:
+    if not signature_header or not signature_header.startswith("sha256="):
+        return False
+    received = signature_header.split("=", 1)[1]
+    mac = hmac.new(secret.encode("utf-8"), msg=body, digestmod=hashlib.sha256)
+    expected = mac.hexdigest()
+    return hmac.compare_digest(received, expected)
+
+@app.post("/webhook")
+async def webhook(
+    request: Request,
+    x_hub_signature_256: Optional[str] = Header(default=None, alias="X-Hub-Signature-256"),
+    x_github_event: Optional[str] = Header(default=None, alias="X-GitHub-Event"),
+    x_github_delivery: Optional[str] = Header(default=None, alias="X-GitHub-Delivery"),
+):
+    raw = await request.body()
+    if not verify_signature(WEBHOOK_SECRET, raw, x_hub_signature_256):
+        raise HTTPException(status_code=401, detail="Invalid signature")
+
+    if x_github_event not in ("issues", "issue_comment", "ping"):
+        raise HTTPException(status_code=400, detail=f"Unsupported event: {x_github_event}")
+
+    payload = json.loads(raw.decode("utf-8") or "{}")
+    action = payload.get("action")
+    issue_number = payload.get("issue", {}).get("number") if isinstance(payload.get("issue"), dict) else None
+
+    now = int(time.time())
+    async with aiosqlite.connect(DB_PATH) as db:
+        try:
+            await db.execute(
+                "INSERT INTO events (id, event, action, issue_number, timestamp) VALUES (?, ?, ?, ?, ?)",
+                (x_github_delivery, x_github_event, action, issue_number, now),
+            )
+            await db.commit()
+        except aiosqlite.IntegrityError:
+            pass  # duplicate delivery id → idempotent
+
+    return Response(status_code=204)
+
+class EventOut(BaseModel):
+    id: str
+    event: str
+    action: Optional[str]
+    issue_number: Optional[int]
+    timestamp: int
+
+@app.get("/events", response_model=List[EventOut])
+async def get_events(n: int = 20):
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            "SELECT id, event, action, issue_number, timestamp FROM events ORDER BY timestamp DESC LIMIT ?",
+            (n,),
+        ) as cursor:
+            rows = await cursor.fetchall()
+            return [EventOut(**dict(r)) for r in rows]
+
+@app.get("/healthz")
+async def healthz():
+    return {"ok": True}
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn[standard]
+httpx
+python-dotenv
+pydantic
+aiosqlite


### PR DESCRIPTION
Summary

Implements Step 5 (Webhook Handling) for HW2:

POST /webhook:

Verifies HMAC SHA-256 using WEBHOOK_SECRET.

Accepts issues, issue_comment, and ping events.

Persists events to SQLite (events.db) with idempotency by delivery id.

Returns 204 on success.

GET /events:

Returns the last N stored webhook deliveries (default 20).

Supports frontend “Display events” tab.

GET /healthz endpoint for health checks.

Runtime Notes

Requires .env file with variables (not committed to git, .env is ignored):

GITHUB_TOKEN=...
GITHUB_OWNER=zachJX-SJSU
GITHUB_REPO=TeamACIDic_HW2_test_repo
WEBHOOK_SECRET=...
PORT=5000

Testing

Run service:

uvicorn app.main:app --host 0.0.0.0 --port $PORT


GitHub webhook → Settings → Webhooks → “Recent deliveries” → Response 204.

Verify storage:

curl http://<EC2_DNS>:5000/events


Returns stored ping/issue events.

Next Steps

Add Dockerfile in a follow-up PR for final Dockerization step.

Extend OpenAPI spec to cover /webhook and /events.

Add test coverage for signature verification and event persistence.