### PR TITLE
fix(webhook): robust payload parsing + SQLite persistence

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -48,16 +48,41 @@ async def webhook(
     x_github_delivery: Optional[str] = Header(default=None, alias="X-GitHub-Delivery"),
 ):
     raw = await request.body()
+
+    # Verify HMAC (required by spec)
     if not verify_signature(WEBHOOK_SECRET, raw, x_hub_signature_256):
         raise HTTPException(status_code=401, detail="Invalid signature")
 
+    # Only handle these events
     if x_github_event not in ("issues", "issue_comment", "ping"):
         raise HTTPException(status_code=400, detail=f"Unsupported event: {x_github_event}")
 
-    payload = json.loads(raw.decode("utf-8") or "{}")
-    action = payload.get("action")
-    issue_number = payload.get("issue", {}).get("number") if isinstance(payload.get("issue"), dict) else None
+    # ---- Robust payload parsing: JSON OR x-www-form-urlencoded (payload=<json>) ----
+    content_type = (request.headers.get("content-type") or "").lower()
+    body_text = raw.decode("utf-8") if raw else ""
 
+    if "application/json" in content_type:
+        body_json_text = body_text or "{}"
+    elif "application/x-www-form-urlencoded" in content_type:
+        import urllib.parse
+        form = urllib.parse.parse_qs(body_text)
+        body_json_text = form.get("payload", ["{}"])[0]
+    else:
+        # Fallback: try JSON; if empty or bad, ack 204 so GitHub will not keep retrying
+        body_json_text = body_text or "{}"
+
+    try:
+        payload = json.loads(body_json_text)
+    except json.JSONDecodeError:
+        # Acknowledge but don't store malformed bodies
+        return Response(status_code=204)
+
+    # Extract fields safely
+    action = payload.get("action")
+    issue = payload.get("issue") if isinstance(payload.get("issue"), dict) else None
+    issue_number = issue.get("number") if isinstance(issue, dict) else None
+
+    # Persist (idempotent on delivery id)
     now = int(time.time())
     async with aiosqlite.connect(DB_PATH) as db:
         try:
@@ -67,7 +92,8 @@ async def webhook(
             )
             await db.commit()
         except aiosqlite.IntegrityError:
-            pass  # duplicate delivery id → idempotent
+            pass  # duplicate delivery id → ignore
+
 
     return Response(status_code=204)
 


### PR DESCRIPTION
Fix webhook parsing to support both application/json and application/x-www-form-urlencoded.
- HMAC verify (secret = proxy)
- Acknowledge 204 on bad/empty payloads
- Persist events to SQLite (idempotent by delivery id)

Verified on EC2: webhook returns 204; /events shows real 'issues' deliveries.
